### PR TITLE
Migrate to zip4j v2

### DIFF
--- a/modules/io/build.gradle
+++ b/modules/io/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     testCompile project(':modules:main').sourceSets.test.output
 
     compile 'org.rauschig:jarchivelib:0.5.0'
-    compile 'net.lingala.zip4j:zip4j:1.3.2'
+    compile 'net.lingala.zip4j:zip4j:2.1.2'
 }
 
 // Exclude caffe package since it is auto generated code and very large

--- a/modules/io/src/main/java/deepboof/io/DeepBoofDataBaseOps.java
+++ b/modules/io/src/main/java/deepboof/io/DeepBoofDataBaseOps.java
@@ -18,7 +18,7 @@
 
 package deepboof.io;
 
-import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 import org.rauschig.jarchivelib.Archiver;
 import org.rauschig.jarchivelib.ArchiverFactory;


### PR DESCRIPTION
zip4j v2 has been released. Switch is straightforward.